### PR TITLE
changed toISOString() into a more elaborate version

### DIFF
--- a/src/codice-fiscale.js
+++ b/src/codice-fiscale.js
@@ -97,7 +97,7 @@ class CodiceFiscale {
             name: this.name,
             surname: this.surname,
             gender: this.gender,
-            birthday: this.birthday.toISOString().slice(0,10),
+            birthday: this.birthday.getFullYear()+"-"+(("00" + this.birthday.getMonth()).slice(-2))+"-"+(("00" + this.birthday.getDate()).slice(-2)),
             birthplace: this.birthplace.nome,
             birthplaceProvincia: this.birthplace.prov,
             cf: this.code,


### PR DESCRIPTION
since the date contains the time zone
new Date("2000-01-01 00:00:00")                            //Sat Jan 01 2000 00:00:00 GMT+0100 . please note GMT+1
converting to ISO, results to convert in UTC
new Date("2000-01-01 00:00:00").toISOString()    //"1999-12-31T23:00:00.000Z" the UTC lose 1 hour